### PR TITLE
Removed bikeshed, added to path and hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This proposal adds support for using designated previous responses, as an extern
 
 HTTP `Content-Encoding` is extended with a new encoding type and support for allowing responses to be used as dictionaries for future requests. *All actual header values and names still TBD*:
 
-* Server responds to a request for a cacheable resource with an `bikeshed-use-as-dictionary: <options>`.
-* The client will store a SHA-256 hash of the uncompressed response and the applicable `scope` for the resource with the cached response to identify it as a dictionary.
-* On future requests, the client will match a request against an available dictionary with the best-matching `scope`. If a dictionary is available for a given request, the client will add `sbr` to the `Accept-Encoding` request header as well as a `sec-bikeshed-available-dictionary: sha-256=:<SHA-256>:` header with the hash of the best available dictionary (only SHA-256 is currently supported).
-* If the server has a compressed version of the request URL with the matching dictionary, it serves the dictonary-compressed response with `Content-Encoding: sbr` and `Vary: Accept-Encoding,sec-bikeshed-available-dictionary`.
+* Server responds to a request for a cacheable resource with an `use-as-dictionary: <options>`.
+* The client will store a hash of the uncompressed response and the applicable `path` for the resource with the cached response to identify it as a dictionary.
+* On future requests, the client will match a request against an available dictionary with the best-matching `path`. If a dictionary is available for a given request, the client will add `sbr` to the `Accept-Encoding` request header as well as a `sec-available-dictionary: <SHA-256>` header with the hash of the best available dictionary (only SHA-256 is currently supported).
+* If the server has a compressed version of the request URL with the matching dictionary, it serves the dictonary-compressed response with `Content-Encoding: sbr` and `Vary: Accept-Encoding,sec-available-dictionary`.
 
 For interop reasons, `sbr` compression is only supported on secure contexts (similar to brotli compression).
 
 There are also some browser-specific features independent of the transport compression:
 * For security and privacy reasons, there are [CORS](https://fetch.spec.whatwg.org/#http-cors-protocol) requirements ([detailed below](#security-mitigations)) for both the dictionary and compressed resource.
-* In order to populate a dictionary for future use, a server can respond with link tag or header to trigger an idle-time fetch specifically for a dictionary for future use. i.e. `<link rel=bikeshed-dictionary href=[dictionary_url]>`.
+* In order to populate a dictionary for future use, a server can respond with link tag or header to trigger an idle-time fetch specifically for a dictionary for future use. i.e. `<link rel=dictionary href=[dictionary_url]>`.
 
 ## Background
 ### What are compression dictionaries?
@@ -68,7 +68,7 @@ In both cases the client advertises the best-available dictionary that it has fo
 
 With the `Delta compression` use case, a previously-downloaded version of the resource is available to use for future requests as a dictionary. For example, with a JavaScript file, v1 of the file may be in the browser's cache and available for use as a dictionary to use when fetching v2 so only the difference between the two needs to be transmitted.
 
-In the `Shared dictionary` use case, the dictionary is a purpose-built dictionary that is fetched using a `<link>` tag and can be used for future requests that match the `scope` covered by the dictionary. For example, on a first visit to a site, the HTML response references a custom dictionary that should be used for `document` fetches for that origin. The dictionary is downloaded at some point by the browser and, on future navigations through the site, is advertised as being available for document requests that match the scope of the dictionary.
+In the `Shared dictionary` use case, the dictionary is a purpose-built dictionary that is fetched using a `<link>` tag and can be used for future requests that match the `path` covered by the dictionary. For example, on a first visit to a site, the HTML response references a custom dictionary that should be used for `document` fetches for that origin. The dictionary is downloaded at some point by the browser and, on future navigations through the site, is advertised as being available for document requests that match the path of the dictionary.
 
 ## Risks
 
@@ -103,39 +103,41 @@ For some large and heavily trafficked sites, that case is rare. For others, it�
 In this flow, we’re reusing static resources themselves as dictionaries that would be used to compress future updates of themselves, or similar resources.
 
 * [example.com](http://example.com/) downloads [example.com/large-module.wasm](http://example.com/large-module.wasm) for the first time.
-* The response for [example.com/large-module.wasm](http://example.com/large-module.wasm) contains a `bikeshed-use-as-dictionary: <options>` response header. The options are a [structured field dictionary](https://www.rfc-editor.org/rfc/rfc8941.html#name-dictionaries) that includes the ability to set path/scope, expiration and preferred hashes. More details [here](#dictionary-options-header).
+* The response for [example.com/large-module.wasm](http://example.com/large-module.wasm) contains a `use-as-dictionary: <options>` response header. The options are a [structured field dictionary](https://www.rfc-editor.org/rfc/rfc8941.html#name-dictionaries) that includes the ability to set path, expiration and preferred hashes. More details [here](#dictionary-options-header).
 * The client saves the path and a SHA-256 hash of the resource with the cached resource.
     * For browser clients, the response must also be non-opaque in order to be used as a dictionary. Practically, this means the response is either same-origin as the document or has an `Access-Control-Allow-Origin:` header that makes the response readable by the document.
-* The next time the browser fetches a resource from said path while the resource is available in cache, it includes a `sec-bikeshed-available-dictionary:` request header, which lists a **single** SHA-256 hash
-    * SHA-256 hashes are long. Their hex representation would be 64 bytes, and we can base64 them to be ~42 (I think). We can't afford to send many hashes for both performance and privacy reasons.
+* The next time the browser fetches a resource from a path covered by a dictionary in cache, it includes a `sec-available-dictionary:` request header, which lists a **single** hash (lowercase hex)
+    * The request is limited to specifying a **single** dictionary hash both to reduce the header overhead and limit the cardinality of the `sec-available-dictionary:` request header (to limit variations in the `Vary` caches).
     * The `sec-` prefix is there to ensure that requests are not attacker-generated.
-    * Any new resource as a dictionary for that path would override older ones. When sending requests, the browser would use the _most specific path_ for the request to get its dictionary.
-* When the server gets a request with the `sec-bikeshed-available-dictionary` header in it:
+    * Any new resource as a dictionary for that path would override older ones. When sending requests, the browser would use the _most specific path_ for the request to get its dictionary. Path specificity is determined by the string length of the path specified with the dictionary.
+    * The different SHA hash algorithms have different lengths so the actual algorithm doesn't need to be specified.
+    * The hex representation of a SHA-256 hash is relatively long at 64 bytes and it could be reduced to ~42 bytes if bas64 was used. By specifying the lowecase hex representation it makes processing of the request on the server much easier (and the hash value can be directly matched to part of a filename on-disk).
+* When the server gets a request with the `sec-available-dictionary` header in it:
     * If the client sent a `sec-fetch-mode: cors` request header then the dictionary should be ignored unless the response will have an `Access-Control-Allow-Origin:` response header that includes the origin of the page the request was issued from (`*` or matched against the `origin:` or `referer:`).
     * The server can simply ignore the dictionary if it doesn't have a diff that corresponds to said dictionary. In that case the server can serve the response without delta compression.
     * If the server does have a corresponding diff, it can respond with that, indicating that as part of its `content-encoding` header. There's no need to repeat the hash value, as there's only one.
-      - For example, if we're using [shared brotli compression](https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/), the `content-encoding: sbr` header can indicate that.
+      - For example, if we're using [shared brotli compression](https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/), the `content-encoding: sbr` header would respond with `Content-Encoding: sbr`.
 * In case the browser advertized a dictionary but then fails to successfully fetch it from its cache *and* the dictionary was used by the server, the resource request should fail.
 * For browser clients, the response must be non-opaque in order to be decompressed with a shared dictionary. Practically, this means the response is either same-origin as the document or has an `Access-Control-Allow-Origin:` header that makes the response readable by the document.
 
 ### Dynamic resources flow
 
-* Shared dictionary is declared ahead-of time and then downloaded out of band using a `Link:` header on the document response or `<link>` HTML tag with a `rel=bikeshed-dictionary` type.
+* Shared dictionary is declared ahead-of time and then downloaded out of band using a `Link:` header on the document response or `<link>` HTML tag with a `rel=dictionary` type.
     * The dictionary resource will be downloaded with CORS in “omit” mode to discourage including user-specific private data in the dictionary, since its data will be readable without credentials.
     * It will be downloaded with “idle” priority, once the site is actually idle.
     * Browsers may decide to not download it when they suspect that the user is paying for bandwidth, or when used by sites that are not likely to amortize the dictionary costs (e.g. sites that the user isn’t visiting frequently enough).
     * Browsers may decide to not use a shared dictionary if it contains hints that its contents are not public (e.g. `Cache-Control: private` headers).
-* The dictionary response must include the `bikeshed-use-as-dictionary: <options>` header, appropriate cache lifetime headers and will be used for future requests using the same process as the [Static resources flow](#static-resources-flow).
+* The dictionary response must include the `use-as-dictionary: <options>` header, appropriate cache lifetime headers and will be used for future requests using the same process as the [Static resources flow](#static-resources-flow).
     * For browser clients, the response must also be non-opaque in order to be used as a dictionary. Practically, this means the response is either same-origin as the document or has an `Access-Control-Allow-Origin:` header that makes the response readable by the document.
 
 ### Dictionary options header
-The `bikeshed-use-as-dictionary:` response header is a [structured field dictionary](https://www.rfc-editor.org/rfc/rfc8941.html#name-dictionaries) that allows for setting multiple options and for future expansion.  The supported options and defaults are:
+The `use-as-dictionary:` response header is a [structured field dictionary](https://www.rfc-editor.org/rfc/rfc8941.html#name-dictionaries) that allows for setting multiple options and for future expansion.  The supported options and defaults are:
 
-* **p** - Path for the dictionary to apply to. *Required*. The path will be prefix-matched to requests. i.e. `/app1/main` will match `https://www.example.com/app1/main_12345.js`. Also supports relative-path matching if not prefixed with `/`. i.e. `main` in response to `https://www.example.com/app1/main_1.js` will match `https://www.example.com/app1/main.xyz.js`.
+* **p** - Path for the dictionary to apply to. *Required*. The path supports relative or absolute paths as well as `*` wildcard expansion. i.e. `/app1/main*` will match `https://www.example.com/app1/main_12345.js` and `main*` in response to `https://www.example.com/app1/main_1.js` will match `https://www.example.com/app1/main.xyz.js`.
 * **e** - Expiration time in seconds for the dictionary. *Defaults to 31536000 (1 year)*. This is independent of the cache lifetime of the resource being used for the dictionary. If the underlying resource is evicted from cache then it is also removed but this allows for setting an explicit time to live for use as a dictionary independent of the underlying resource in cache. Expired resources can still be useful as dictionaries while they are in cache and can be used for fetching updates of the expired resource. It can also be useful to artificially limit the life of a dictionary in cases where the dictionary is updated frequently, to limit the number of possible incoming dictionary values.
 * **h** - List of supported hash algorithms in order of server preference. Defaults to `(sha-256)` which is the only supported algorithm currently but allows for future migration to different hash algorithms.
 
-For example: `bikeshed-use-as-dictionary: p="/app1/main", e=604800, h=(sha-256 sha-512)` would specify matching on a path prefix of `/app1/main`, expiring as a dictionary in 7 days, independent of the cache lifetime of the resource and advertise support for both sha-256 and sha-512.
+For example: `use-as-dictionary: p="/app1/main", e=604800, h=(sha-256 sha-512)` would specify matching on a path prefix of `/app1/main`, expiring as a dictionary in 7 days, independent of the cache lifetime of the resource and advertise support for both sha-256 and sha-512.
 
 ### Compression API
 
@@ -144,15 +146,15 @@ The compression API can also expose support for using caller-supplied dictionari
 ## Security and Privacy
 
 ### Dictionary and Resource readability (CORS)
-Since the contents of the dictionary and compressed resource are both effectively readable through side-channel attacks, this proposal makes it explicit and requires that both be CORS-readable from the document origin. The dictionary and compressed resource must also be from the same origin as each other with the `scope` only comprising the path component of the matching URL.
+Since the contents of the dictionary and compressed resource are both effectively readable through side-channel attacks, this proposal makes it explicit and requires that both be CORS-readable from the document origin. The dictionary and compressed resource must also be from the same origin as each other with the `path` only comprising the path component of the matching URL.
 
 For dictionaries and resources that are same-origin as the document, no additional requirements exist as both are CORS-readable from the document context. For navigation requests, their resource is by definition same-origin as the document their response will eventually commit. As a result, the dictionaries that apply to their path are similarly same-origin.
 
 For dictionaries and resources served from a different origin than the document, they must be CORS-readable from the document origin. i.e. `Access-Control-Allow-Origin: <document origin or *>`.
 
-When sending a CORS request with an available dictionary, a browser should only include the `sec-bikeshed-available-dictionary:` header if it is also sending the `sec-fetch-mode:` header so a CORS-readable decision can be made on the server before responding.
+When sending a CORS request with an available dictionary, a browser should only include the `sec-available-dictionary:` header if it is also sending the `sec-fetch-mode:` header so a CORS-readable decision can be made on the server before responding.
 
-In order to prevent sending dictionary-compressed responses that the client will not be able to process, when a server receives a request with `sec-fetch-mode: cors` as well as a `sec-bikeshed-available-dictionary:` dictionary, it should only use the dictionary if the response includes a `Access-Control-Allow-Origin:` response header that includes the origin of the page the request was made from. Either by virtue of `Access-Control-Allow-Origin: *` covering all origins or if `Access-Control-Allow-Origin:` includes the origin in the `origin:` or `referer:` request header. If there is no `origin:` or `referer:` request header and `Access-Control-Allow-Origin:` is not `*` then the dictionary should not be used.
+In order to prevent sending dictionary-compressed responses that the client will not be able to process, when a server receives a request with `sec-fetch-mode: cors` as well as a `sec-available-dictionary:` dictionary, it should only use the dictionary if the response includes a `Access-Control-Allow-Origin:` response header that includes the origin of the page the request was made from. Either by virtue of `Access-Control-Allow-Origin: *` covering all origins or if `Access-Control-Allow-Origin:` includes the origin in the `origin:` or `referer:` request header. If there is no `origin:` or `referer:` request header and `Access-Control-Allow-Origin:` is not `*` then the dictionary should not be used.
 
 To discourage encoding user-specific private information into the dictionaries, any out-of-band dictionaries fetched using a `<link>` will be uncredentialed fetches.
 
@@ -164,21 +166,18 @@ The existence of a dictionary is effectively a cookie for any requests that matc
 The existence of support for `content-encoding: sbr` has the potential to leak client state information if not applied consistently. If the browser supports `sbr` encoding then it should always be advertised, independent of the current state of the feature. Specifically, this means that in any private browsing mode (Incognito in Chrome), `sbr` support should still be advertised even if the dictionaries will not persist so that the state of the private browsing mode is not exposed.
 
 ### Triggering dictionary fetches
-The explicit fetching of a dictionary through a `<link rel=bikeshed-dictionary>` tag or `Link:` header is functionally equivalent to `<link rel=preload>` with different priority and should be treated as such. This means that the `Link:` header is only effective for document navigation responses and can not be used for subresource loads.
+The explicit fetching of a dictionary through a `<link rel=dictionary>` tag or `Link:` header is functionally equivalent to `<link rel=preload>` with different priority and should be treated as such. This means that the `Link:` header is only effective for document navigation responses and can not be used for subresource loads.
 
 This prevents passive resources, like images, from using the dictionary fetch as a side-channel for sending information.
 
 ## Cache/CDN considerations
-Any caches between the server and the client will need to be able to support `Vary` on both `Accept-Encoding` and `sec-bikeshed-available-dictionary`, otherwise the responses will be either corrupt (in the case of serving a sbr resource with the wrong dictionary) or ineffective (serving the brotli-compressed resource when sbr was possible).
+Any caches between the server and the client will need to be able to support `Vary` on both `Accept-Encoding` and `sec-available-dictionary`, otherwise the responses will be either corrupt (in the case of serving a sbr resource with the wrong dictionary) or ineffective (serving the brotli-compressed resource when sbr was possible).
 
 Any middle-boxes in the request flow will also need to support the `sbr` content-encoding, either by passing it through unmodified or by managing the appropriate dictionaries and compressed resources.
 
 ## Open Questions
 
 1. Should there be a way to delete dictionaries deeper in the tree? i.e. `/dictionary` wants to replace `/dir1/xxx/dictionary2`. Otherwise the specificity rules will pick dictionary2 until it is purged from cache.
-1. Should there be a way to support wildcards inside of the path/scope? i.e. `/app/resources/12345/main.js` where the build number is in the path ahead of the file name?
-    * This would complicate the specificity rules.
-    * This would break the "same directory or lower" rules.
 
 ## Examples
 
@@ -189,32 +188,32 @@ In this example, www.example.com will use a bundle of application JavaScript tha
 On the initial visit to the site:
 * The browser loads https://www.example.com/ which contains `<script src="//static.example.com/app/main.js/123">` (where 123 is the build number of the code).
 * The browser requests https://static.example.com/app/main.js/123 with `Accept-Encoding: sbr,br,gzip`.
-* The server for static.example.com responds with the file as well as `bikeshed-use-as-dictionary: p="/app/main.js"`, `Access-Control-Allow-Origin: https://www.example.com` and `Vary: Accept-Encoding,sec-bikeshed-available-dictionary`.
-* The browser caches the js file along with a SHA-256 hash of the decompressed file and the `/app/main.js` scope.
+* The server for static.example.com responds with the file as well as `use-as-dictionary: p="/app/main.js"`, `Access-Control-Allow-Origin: https://www.example.com` and `Vary: Accept-Encoding,sec-available-dictionary`.
+* The browser caches the js file along with a SHA-256 hash of the decompressed file and the `/app/main.js` path.
 
 ```mermaid
 sequenceDiagram
 Browser->>www.example.com: GET /
 www.example.com->>Browser: ...<script src="//static.example.com/app/main.js/123">...
 Browser->>static.example.com: GET /app/main.js/123<br/>Accept-Encoding: sbr,br,gzip
-static.example.com->>Browser: bikeshed-use-as-dictionary: p="/app/main.js"<br/>Access-Control-Allow-Origin: https://www.example.com<br/>Vary: Accept-Encoding,sec-bikeshed-available-dictionary
+static.example.com->>Browser: use-as-dictionary: p="/app/main.js"<br/>Access-Control-Allow-Origin: https://www.example.com<br/>Vary: Accept-Encoding,sec-available-dictionary
 ```
 
 At build time, the site developer creates delta-compressed versions of main.js using previous builds as dictionaries, storing the delta-compressed version along with the SHA-256 hash of the dictionary used (i.e. as `main.js.<hash>.sbr`).
 
 On a future visit to the site after the application code has changed:
 * The browser loads https://www.example.com/ which contains `<script src="//static.example.com/app/main.js/125">`.
-* The browser matches the `/app/main.js/125` request with the `/app/main.js` path of the previous response that is in cache and requests https://static.example.com/app/main.js/125 with `Accept-Encoding: sbr,br,gzip`, `sec-fetch-mode: cors` and `sec-bikeshed-available-dictionary: sha-256=:<SHA-256 HASH>:`.
-* The server for static.example.com matches the URL and hash with the pre-compressed artifact from the build and responds with it and `Content-Encoding: sbr`, `Access-Control-Allow-Origin: https://www.example.com`, `Vary: Accept-Encoding,sec-bikeshed-available-dictionary`.
+* The browser matches the `/app/main.js/125` request with the `/app/main.js` path of the previous response that is in cache and requests https://static.example.com/app/main.js/125 with `Accept-Encoding: sbr,br,gzip`, `sec-fetch-mode: cors` and `sec-available-dictionary: <SHA-256 HASH>`.
+* The server for static.example.com matches the URL and hash with the pre-compressed artifact from the build and responds with it and `Content-Encoding: sbr`, `Access-Control-Allow-Origin: https://www.example.com`, `Vary: Accept-Encoding,sec-available-dictionary`.
 
-It could have also included a new `bikeshed-use-as-dictionary: p="/app/main.js"` response header to have the new version of the file replace the old one as the dictionary to use for future requests for the path but that is not a requirement for the existing dictionary to have been used.
+It could have also included a new `use-as-dictionary: p="/app/main.js"` response header to have the new version of the file replace the old one as the dictionary to use for future requests for the path but that is not a requirement for the existing dictionary to have been used.
 
 ```mermaid
 sequenceDiagram
 Browser->>www.example.com: GET /
 www.example.com->>Browser: ...<script src="//static.example.com/app/main.js/125">...
-Browser->>static.example.com: GET /app/main.js/125<br/>Accept-Encoding: sbr,br,gzip<br/>sec-fetch-mode: cors<br/>sec-bikeshed-available-dictionary: sha-256=:[SHA-256 HASH]:
-static.example.com->>Browser: Content-Encoding: sbr<br/>Access-Control-Allow-Origin: https://www.example.com<br/>Vary: Accept-Encoding,sec-bikeshed-available-dictionary
+Browser->>static.example.com: GET /app/main.js/125<br/>Accept-Encoding: sbr,br,gzip<br/>sec-fetch-mode: cors<br/>sec-available-dictionary: [SHA-256 HASH]
+static.example.com->>Browser: Content-Encoding: sbr<br/>Access-Control-Allow-Origin: https://www.example.com<br/>Vary: Accept-Encoding,sec-available-dictionary
 ```
 
 ### Site-specific dictionary used for all document navigations in a part of the site
@@ -222,25 +221,25 @@ static.example.com->>Browser: Content-Encoding: sbr<br/>Access-Control-Allow-Ori
 In this example, www.example.com has a custom-built dictionary that should be used for all navigation requests to /product.
 
 On the initial visit to the site:
-* The browser loads https://www.example.com which contains `<link rel=bikeshed-dictionary href="/product/dictionary_v1.dat">`.
+* The browser loads https://www.example.com which contains `<link rel=dictionary href="/product/dictionary_v1.dat">`.
 * At an idle time, the browser sends an uncredentialed fetch request for https://www.example.com/product/dictionary_v1.dat.
-* The server for www.example.com responds with the dictionary contents as well as `bikeshed-use-as-dictionary: p="/product/"` and appropriate caching headers.
-* The browser caches the dictionary file along with a SHA-256 hash of the decompressed file and the `/app/main.js` scope.
+* The server for www.example.com responds with the dictionary contents as well as `use-as-dictionary: p="/product/"` and appropriate caching headers.
+* The browser caches the dictionary file along with a SHA-256 hash of the decompressed file and the `/app/main.js` path.
 
 ```mermaid
 sequenceDiagram
 Browser->>www.example.com: GET /
-www.example.com->>Browser: ...<link rel=bikeshed-dictionary href="/product/dictionary_v1.dat">...
+www.example.com->>Browser: ...<link rel=dictionary href="/product/dictionary_v1.dat">...
 Browser->>www.example.com: GET /product/dictionary_v1.dat<br/>Accept-Encoding: sbr,br,gzip
-www.example.com->>Browser: bikeshed-use-as-dictionary: p="/product/"
+www.example.com->>Browser: use-as-dictionary: p="/product/"
 ```
 
 At some point after the dictionary has been fetched, the user clicks on a link to https://www.example.com/product/myproduct:
-* The browser matches the `/product/myproduct` request with the `/product` path of the previous dictionary request and requests https://www.example.com/product/myproduct with `Accept-Encoding: sbr,br,gzip` and `sec-bikeshed-available-dictionary: sha-256=:<SHA-256 HASH>:`.
+* The browser matches the `/product/myproduct` request with the `/product` path of the previous dictionary request and requests https://www.example.com/product/myproduct with `Accept-Encoding: sbr,br,gzip` and `sec-available-dictionary: <SHA-256 HASH>`.
 * The server supports dynamically compressing responses using available dictionaries and has the dictionary with the same hash available and responds with a brotli-compressed version of the response using the specified dictionary and `Content-Encoding: sbr` (and Vary headers if the response is cacheable).
 
 ```mermaid
 sequenceDiagram
-Browser->>www.example.com: GET /product/myproduct<br/>Accept-Encoding: sbr,br,gzip<br/>sec-bikeshed-available-dictionary: sha-256=:[SHA-256 HASH]:
+Browser->>www.example.com: GET /product/myproduct<br/>Accept-Encoding: sbr,br,gzip<br/>sec-available-dictionary: [SHA-256 HASH]
 www.example.com->>Browser: Content-Encoding: sbr
 ```


### PR DESCRIPTION
* Removed all bikeshed- prefixes on headers and values (let the actual bikeshedding begin).
* Updated the path definition to allow for wildcard expansion. This matches what the extensions API uses for URL matching so even though `*` is a valid path character, it is consistent with existing URL path matching APIs.
* Changed the `sec-available-dictionary:` request header to send a lowecase hex hash value (not as a structured field) to make server-side processing easier. It's a little bit longer but significantly improves deployability.

Fix #22
Fix #16